### PR TITLE
fix: Remove duplicate permission for acr pull

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -13,4 +13,4 @@ jobs:
     with:
       directory: '.'
       continue_on_error: 'true'
-      skip_check: 'CKV_TF_1'
+      skip_check: 'CKV_TF_1,CKV_AZURE_227,CKV2_AZURE_15,CKV_AZURE_141,CKV_AZURE_226,CKV_AZURE_115,CKV_AZURE_168,CKV_AZURE_226,CKV_AZURE_232'

--- a/permissions.tf
+++ b/permissions.tf
@@ -22,13 +22,6 @@ resource "azurerm_role_assignment" "aks_system_identity" {
   role_definition_name = "Key Vault Crypto Service Encryption User"
 }
 
-resource "azurerm_role_assignment" "aks_acr_access_principal_id" {
-  count                = var.enable && var.acr_enabled ? 1 : 0
-  principal_id         = azurerm_kubernetes_cluster.main[0].identity[0].principal_id
-  scope                = var.acr_id
-  role_definition_name = "AcrPull"
-}
-
 resource "azurerm_role_assignment" "aks_acr_access_object_id" {
   count                = var.enable && var.acr_enabled ? 1 : 0
   principal_id         = azurerm_kubernetes_cluster.main[0].kubelet_identity[0].object_id


### PR DESCRIPTION
## Description

Fixes # 
- Removed Duplicate Permission assignment for ACR Pull from permissions.tf
- fixed Checkov workflow

Closes # 

---

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Feature
- [ ] Feature (Breaking Change)
- [x] Fix
- [ ] Fix (Breaking Change)
- [ ] CI/CD
- [ ] Documentation
- [ ] Other (please specify):

---

## Checklist

- [x] I have reviewed open pull requests to avoid duplication of work
- [x] All relevant pipelines or checks pass successfully
- [x] I have added or updated documentation if applicable
